### PR TITLE
Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 |:-|:-:|
 | [1. Code Repository](https://fair-software.nl/recommendations/repository)       | [![GitHub URL](https://img.shields.io/badge/github-repo-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/DeepRank/pssmgen) |
 | &nbsp;                                                                          | [![GitHub](https://img.shields.io/github/last-commit/DeepRank/pssmgen)](https://github.com/DeepRank/pssmgen) |
-| [2. License](https://fair-software.nl/recommendations/license)                  | [![License](https://img.shields.io/github/license/DeepRank/pssmgen)](https://github.com/citation-file-format/cff-converter-python) |
+| [2. License](https://fair-software.nl/recommendations/license)                  | [![License](https://img.shields.io/github/license/DeepRank/pssmgen)](https://github.com/DeepRank/pssmgen) |
 | [3. Community Registry](https://fair-software.nl/recommendations/registry)      | [![Research Software Directory](https://img.shields.io/badge/rsd-PSSMGen-00a3e3.svg&labelColor=gray&color=00a3e3)](https://research-software.nl/software/pssmgen) |
 | &nbsp;                                                                          | [![PyPI](https://img.shields.io/pypi/v/pssmgen)](https://pypi.org/project/pssmgen/) |
 | [4. Enable Citation](https://fair-software.nl/recommendations/citation)         | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3635711.svg)](https://doi.org/10.5281/zenodo.3635711) |

--- a/README.md
+++ b/README.md
@@ -1,9 +1,33 @@
 # PSSMGen
 
-[![PyPI](https://img.shields.io/pypi/v/pssmgen)](https://pypi.org/project/pssmgen/)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3635711.svg)](https://doi.org/10.5281/zenodo.3635711)
-[![RSD](https://img.shields.io/badge/RSD-PSSMGen-red)](https://research-software.nl/software/pssmgen)
+| fair-software.nl recommendations | Badges |
+|:-|:-:|
+| [1. Code Repository](https://fair-software.nl/recommendations/repository)       | [![GitHub URL](https://img.shields.io/badge/github-repo-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/DeepRank/pssmgen) |
+| &nbsp;                                                                          | [![GitHub](https://img.shields.io/github/last-commit/DeepRank/pssmgen)](https://github.com/DeepRank/pssmgen) |
+| [2. License](https://fair-software.nl/recommendations/license)                  | [![License](https://img.shields.io/github/license/DeepRank/pssmgen)](https://github.com/citation-file-format/cff-converter-python) |
+| [3. Community Registry](https://fair-software.nl/recommendations/registry)      | [![Research Software Directory](https://img.shields.io/badge/rsd-PSSMGen-00a3e3.svg&labelColor=gray&color=00a3e3)](https://research-software.nl/software/pssmgen) |
+| &nbsp;                                                                          | [![PyPI](https://img.shields.io/pypi/v/pssmgen)](https://pypi.org/project/pssmgen/) |
+| [4. Enable Citation](https://fair-software.nl/recommendations/citation)         | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3635711.svg)](https://doi.org/10.5281/zenodo.3635711) |
+| [5. Code Quality Checklist](https://fair-software.nl/recommendations/checklist) | [![cii best practices](https://bestpractices.coreinfrastructure.org/projects/1811/badge)](https://bestpractices.coreinfrastructure.org/projects/1811)  |
 
+<!--
+
+| **Other**                                                                       | **Badge** |
+| Continuous Integration                                                          | [![Build Status](https://travis-ci.org/research-software-directory/research-software-directory.svg?branch=master)](https://travis-ci.org/research-software-directory/research-software-directory) |
+| &nbsp;                                                                          | [![Build status](https://ci.appveyor.com/api/projects/status/vki0xma8y7glpt09/branch/master?svg=true)](https://ci.appveyor.com/project/NLeSC/xenon-cli/branch/master)  |
+| Code Analysis                                                                   | [![CodeClimate](https://api.codeclimate.com/v1/badges/ed3655f6056f89f5e107/maintainability)](https://codeclimate.com/github/DynaSlum/satsense/maintainability) |
+| &nbsp;                                                                          | [![Codacy Badge](https://api.codacy.com/project/badge/Grade/6e3836750fe14f34ba85e26956e8ef10)](https://www.codacy.com/app/c-meijer/eEcoLiDAR?utm_source=www.github.com&amp;utm_medium=referral&amp;utm_content=eEcoLiDAR/eEcoLiDAR&amp;utm_campaign=Badge_Grade) |
+| &nbsp;                                                                          | [![SonarCloud](https://sonarcloud.io/api/project_badges/measure?project=nlesc%3AXenon&metric=alert_status)](https://sonarcloud.io/dashboard?id=nlesc%3AXenon) |
+| Code Coverage                                                                   | [![codecov](https://codecov.io/gh/wadpac/GGIR/branch/master/graph/badge.svg)](https://codecov.io/gh/wadpac/GGIR) |
+| &nbsp; | [![SonarCloud](https://sonarcloud.io/api/project_badges/measure?project=xenon-middleware_xenon-grpc&metric=coverage)](https://sonarcloud.io/component_measures?id=xenon-middleware_xenon-grpc&metric=Coverage) |
+| &nbsp; | [![Scrutinizer](https://scrutinizer-ci.com/g/NLeSC/mcfly/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/NLeSC/mcfly/statistics/) |
+| &nbsp; | [![Coveralls](https://coveralls.io/repos/github/eEcoLiDAR/eEcoLiDAR/badge.svg)](https://coveralls.io/github/eEcoLiDAR/eEcoLiDAR) |
+| &nbsp; | [![CodeClimate](https://api.codeclimate.com/v1/badges/ed3655f6056f89f5e107/test_coverage)](https://codeclimate.com/github/DynaSlum/satsense/test_coverage) |
+| Documentation                                                                   | [![ReadTheDocs](https://readthedocs.org/projects/xenon-tutorial/badge/?version=latest)](https://xenon-tutorial.readthedocs.io/en/latest/?badge=latest) |
+
+_(Customize these badges with your own links. Check https://shields.io/ to see which badges are available.)_
+
+-->
 
 Generates consistent PSSM and/or PDB files for protein-protein complexes
 


### PR DESCRIPTION
This PR adds a few badges accoring to the NLeSC/template format, linking it to the _Five recommendations for FAIR software_ on https://fair-software.nl.

Currently the Code Quality Checklist points to a different project (``cffconvert``), this still needs to be changed. For this go to https://bestpractices.coreinfrastructure.org/en and click "new badge" (I'd be willing to do it for you but I'm not a project admin for PSSMGen.)